### PR TITLE
Support configurable match types for funnel metrics

### DIFF
--- a/app/App/Services/GoogleAnalyticsData/GoogleAnalyticsDataService.php
+++ b/app/App/Services/GoogleAnalyticsData/GoogleAnalyticsDataService.php
@@ -99,8 +99,8 @@ class GoogleAnalyticsDataService
 
                 elseif ($metric['metric'] === 'outboundLinkUsers') {
                     // For outbound links, allow different match types for linkUrl and pagePath
-                    $linkUrlMatchType = $metric['linkUrlMatchType'] ?? $matchType;
-                    $pagePathMatchType = $metric['pagePathMatchType'] ?? 'EXACT';
+                    // $linkUrlMatchType = $metric['linkUrlMatchType'] ?? $matchType;
+                    // $pagePathMatchType = $metric['pagePathMatchType'] ?? 'EXACT';
 
                     $funnelFilterExpressionList[] = [
                         'andGroup' => [
@@ -110,7 +110,7 @@ class GoogleAnalyticsDataService
                                         'fieldName' => 'linkUrl',
                                         'stringFilter' => [
                                             'value' => $metric['linkUrl'],
-                                            'matchType' => $linkUrlMatchType,
+                                            'matchType' => $matchType,
                                         ]
                                     ]
                                 ],
@@ -119,7 +119,7 @@ class GoogleAnalyticsDataService
                                         'fieldName' => 'unifiedPagePathScreen', // Synonymous with pagePath in GA4 reports
                                         'stringFilter' => [
                                             'value' => $metric['pagePath'],
-                                            'matchType' => $pagePathMatchType,
+                                            'matchType' => $matchType
                                         ]
                                     ]
                                 ]
@@ -129,7 +129,7 @@ class GoogleAnalyticsDataService
                 }
                 elseif ($metric['metric'] === 'formUserSubmissions') {
                     // Allow pagePath to use different match type
-                    $pagePathMatchType = $metric['pagePathMatchType'] ?? $matchType;
+                    // $pagePathMatchType = $metric['pagePathMatchType'] ?? $matchType;
 
                     $funnelFilterExpressionList[] = [
                         'andGroup' => [
@@ -148,7 +148,7 @@ class GoogleAnalyticsDataService
                                         'fieldName' => 'unifiedPagePathScreen', // Synonymous with pagePath in GA4 reports
                                         'stringFilter' => [
                                             'value' => $metric['pagePath'],
-                                            'matchType' => $pagePathMatchType,
+                                            'matchType' => $matchType,
                                         ]
                                     ]
                                 ],

--- a/app/App/Services/GoogleAnalyticsData/GoogleAnalyticsDataService.php
+++ b/app/App/Services/GoogleAnalyticsData/GoogleAnalyticsDataService.php
@@ -49,9 +49,12 @@ class GoogleAnalyticsDataService
 
             // Process each metric within the step.
             foreach ($step['metrics'] as $metric) {
+                // Get match type, default to EXACT for backward compatibility
+                $matchType = $metric['matchType'] ?? 'EXACT';
+
                 // Structure the metric based on its type.
                 if ($metric['metric'] === 'pageUsers') {
-                    // Match exact page path
+                    // Match page path with specified match type
                     $funnelFilterExpressionList[] = [
                         'funnelFieldFilter' => [
                             // The page path (web) or screen class (app) on which the event was logged.
@@ -59,14 +62,14 @@ class GoogleAnalyticsDataService
                             'fieldName' => 'unifiedPagePathScreen',
                             'stringFilter' => [
                                 'value' => $metric['pagePath'],
-                                'matchType' => 'EXACT'
+                                'matchType' => $matchType
                             ]
                         ]
                     ];
                 }
 
                 elseif ($metric['metric'] === 'pagePlusQueryStringUsers') {
-                    // Match exact page path plus query string
+                    // Match page path plus query string with specified match type
                     $funnelFilterExpressionList[] = [
                         'funnelFieldFilter' => [
                             // The page path and query string (web) or screen class (app) on which the event was logged.
@@ -74,27 +77,31 @@ class GoogleAnalyticsDataService
                             'fieldName' => 'unifiedPageScreen',
                             'stringFilter' => [
                                 'value' => $metric['pagePathPlusQueryString'],
-                                'matchType' => 'EXACT',
+                                'matchType' => $matchType,
                             ]
                         ]
                     ];
                 }
 
                 if ($metric['metric'] === 'pageTitleUsers') {
-                    // Match exact page path
+                    // Match page title with specified match type
                     $funnelFilterExpressionList[] = [
                         'funnelFieldFilter' => [
                             // The page title (web) or screen name (app) on which the event was logged.
                             'fieldName' => 'unifiedScreenName',
                             'stringFilter' => [
                                 'value' => $metric['pageTitle'],
-                                'matchType' => 'EXACT'
+                                'matchType' => $matchType
                             ]
                         ]
                     ];
                 }
 
                 elseif ($metric['metric'] === 'outboundLinkUsers') {
+                    // For outbound links, allow different match types for linkUrl and pagePath
+                    $linkUrlMatchType = $metric['linkUrlMatchType'] ?? $matchType;
+                    $pagePathMatchType = $metric['pagePathMatchType'] ?? 'EXACT';
+
                     $funnelFilterExpressionList[] = [
                         'andGroup' => [
                             'expressions' => [
@@ -103,7 +110,7 @@ class GoogleAnalyticsDataService
                                         'fieldName' => 'linkUrl',
                                         'stringFilter' => [
                                             'value' => $metric['linkUrl'],
-                                            'matchType' => 'EXACT',
+                                            'matchType' => $linkUrlMatchType,
                                         ]
                                     ]
                                 ],
@@ -112,7 +119,7 @@ class GoogleAnalyticsDataService
                                         'fieldName' => 'unifiedPagePathScreen', // Synonymous with pagePath in GA4 reports
                                         'stringFilter' => [
                                             'value' => $metric['pagePath'],
-                                            'matchType' => 'EXACT',
+                                            'matchType' => $pagePathMatchType,
                                         ]
                                     ]
                                 ]
@@ -121,6 +128,9 @@ class GoogleAnalyticsDataService
                     ];
                 }
                 elseif ($metric['metric'] === 'formUserSubmissions') {
+                    // Allow pagePath to use different match type
+                    $pagePathMatchType = $metric['pagePathMatchType'] ?? $matchType;
+
                     $funnelFilterExpressionList[] = [
                         'andGroup' => [
                             'expressions' => [
@@ -138,7 +148,7 @@ class GoogleAnalyticsDataService
                                         'fieldName' => 'unifiedPagePathScreen', // Synonymous with pagePath in GA4 reports
                                         'stringFilter' => [
                                             'value' => $metric['pagePath'],
-                                            'matchType' => 'EXACT',
+                                            'matchType' => $pagePathMatchType,
                                         ]
                                     ]
                                 ],

--- a/app/Domain/Funnels/Casts/FunnelStepMetricsCast.php
+++ b/app/Domain/Funnels/Casts/FunnelStepMetricsCast.php
@@ -22,22 +22,28 @@ class FunnelStepMetricsCast implements CastsAttributes
                 'metric' => 'pageUsers',
                 'pagePath' => null,
                 'hostname' => null,
+                'matchType' => 'EXACT',
             ],
             'pagePlusQueryStringUsers' => [
                 'metric' => 'pagePlusQueryStringUsers',
                 'pagePathPlusQueryString' => null,
                 'hostname' => null,
+                'matchType' => 'EXACT',
             ],
             'pageTitleUsers' => [
                 'metric' => 'pageTitleUsers',
                 'pageTitle' => null,
                 'hostname' => null,
+                'matchType' => 'EXACT',
             ],
             'outboundLinkUsers' => [
                 'metric' => 'outboundLinkUsers',
                 'pagePath' => null,
                 'linkUrl' => null,
                 'hostname' => null,
+                'matchType' => 'EXACT',
+                'linkUrlMatchType' => 'EXACT',
+                'pagePathMatchType' => 'EXACT',
             ],
             'formUserSubmissions' => [
                 'metric' => 'formUserSubmissions',
@@ -47,13 +53,20 @@ class FunnelStepMetricsCast implements CastsAttributes
                 'formLength' => null,
                 'formSubmitText' => null,
                 'hostname' => null,
+                'matchType' => 'EXACT',
+                'pagePathMatchType' => 'EXACT',
             ],
         ];
 
         return collect(json_decode($value, true))->map(function ($metric) use ($defaultMetricAttributes) {
-            $defaults = $defaultMetricAttributes[$metric['metric']];
+            $defaults = $defaultMetricAttributes[$metric['metric']] ?? [];
 
-            return array_merge($defaults, $metric);
+            $mergedMetric = array_merge($defaults, $metric);
+            if (!isset($mergedMetric['matchType'])) {
+                $mergedMetric['matchType'] = 'EXACT';
+            }
+
+            return $mergedMetric;
         });
     }
 

--- a/app/Domain/Funnels/Enums/MatchType.php
+++ b/app/Domain/Funnels/Enums/MatchType.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace DDD\Domain\Funnels\Enums;
+
+class MatchType
+{
+    public const EXACT = 'EXACT';
+    public const CONTAINS = 'CONTAINS';
+    public const BEGINS_WITH = 'BEGINS_WITH';
+    public const ENDS_WITH = 'ENDS_WITH';
+    public const FULL_REGEXP = 'FULL_REGEXP';
+    public const PARTIAL_REGEXP = 'PARTIAL_REGEXP';
+
+    public static function all(): array
+    {
+        return [
+            self::EXACT,
+            self::CONTAINS,
+            self::BEGINS_WITH,
+            self::ENDS_WITH,
+            self::FULL_REGEXP,
+            self::PARTIAL_REGEXP,
+        ];
+    }
+
+    public static function common(): array
+    {
+        return [
+            self::EXACT,
+            self::CONTAINS,
+            self::BEGINS_WITH,
+            self::ENDS_WITH,
+        ];
+    }
+}

--- a/app/Domain/Funnels/Requests/StepCreateRequest.php
+++ b/app/Domain/Funnels/Requests/StepCreateRequest.php
@@ -5,6 +5,7 @@ namespace DDD\Domain\Funnels\Requests;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Contracts\Validation\Validator;
 use Illuminate\Http\Exceptions\HttpResponseException;
+use DDD\Domain\Funnels\Enums\MatchType;
 
 class StepCreateRequest extends FormRequest
 {
@@ -25,15 +26,20 @@ class StepCreateRequest extends FormRequest
      */
     public function rules()
     {
+        $allowedMatchTypes = implode(',', MatchType::common());
+
         return [
             'order' => 'nullable|numeric',
             'name' => 'nullable|string',
             'metrics' => 'nullable|array',
             'metrics.*.metric' => 'nullable|string',
+            'metrics.*.matchType' => "nullable|string|in:{$allowedMatchTypes}",
             'metrics.*.pagePath' => 'nullable|string',
+            'metrics.*.pagePathMatchType' => "nullable|string|in:{$allowedMatchTypes}",
             'metrics.*.pagePathPlusQueryString' => 'nullable|string',
             'metrics.*.pageTitle' => 'nullable|string',
             'metrics.*.linkUrl' => 'nullable|string',
+            'metrics.*.linkUrlMatchType' => "nullable|string|in:{$allowedMatchTypes}",
             'metrics.*.formDestination' => 'nullable|string',
             'metrics.*.formId' => 'nullable|string',
             'metrics.*.formLength' => 'nullable|string',

--- a/app/Domain/Funnels/Requests/StepUpdateRequest.php
+++ b/app/Domain/Funnels/Requests/StepUpdateRequest.php
@@ -5,6 +5,7 @@ namespace DDD\Domain\Funnels\Requests;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Contracts\Validation\Validator;
 use Illuminate\Http\Exceptions\HttpResponseException;
+use DDD\Domain\Funnels\Enums\MatchType;
 
 class StepUpdateRequest extends FormRequest
 {
@@ -25,15 +26,20 @@ class StepUpdateRequest extends FormRequest
      */
     public function rules()
     {
+        $allowedMatchTypes = implode(',', MatchType::common());
+
         return [
             'order' => 'nullable|numeric',
             'name' => 'nullable|string',
             'metrics' => 'nullable|array',
             'metrics.*.metric' => 'nullable|string',
+            'metrics.*.matchType' => "nullable|string|in:{$allowedMatchTypes}",
             'metrics.*.pagePath' => 'nullable|string',
+            'metrics.*.pagePathMatchType' => "nullable|string|in:{$allowedMatchTypes}",
             'metrics.*.pagePathPlusQueryString' => 'nullable|string',
             'metrics.*.pageTitle' => 'nullable|string',
             'metrics.*.linkUrl' => 'nullable|string',
+            'metrics.*.linkUrlMatchType' => "nullable|string|in:{$allowedMatchTypes}",
             'metrics.*.formDestination' => 'nullable|string',
             'metrics.*.formId' => 'nullable|string',
             'metrics.*.formLength' => 'nullable|string',


### PR DESCRIPTION
## Summary
- add MatchType enum for supported GA match types
- allow funnel steps to specify match types for metrics with defaults
- update GoogleAnalyticsDataService to pass match types to GA filters
- validate matchType inputs when creating or updating steps

## Testing
- `composer install --no-progress --no-interaction --no-scripts` *(fails: your php version (8.4.11) does not satisfy requirements)*
- `vendor/bin/pest` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_b_689f982d85ec8323b6b40790f7948326