### PR TITLE
Add configurable metrics expression for funnel steps

### DIFF
--- a/app/App/Services/GoogleAnalyticsData/GoogleAnalyticsDataService.php
+++ b/app/App/Services/GoogleAnalyticsData/GoogleAnalyticsDataService.php
@@ -7,6 +7,7 @@ use DivisionByZeroError;
 use DDD\Domain\Funnels\Funnel;
 use DDD\Domain\Connections\Connection;
 use DDD\App\Facades\Google\GoogleAuth;
+use DDD\Domain\Funnels\Enums\MetricsExpression;
 
 class GoogleAnalyticsDataService
 {
@@ -214,11 +215,14 @@ class GoogleAnalyticsDataService
                 }
             }
 
+            // Determine the expression type (default to orGroup for backward compatibility)
+            $expressionType = $step['metrics_expression'] ?? MetricsExpression::default();
+
             // Add the structured step to the funnel report API request as a filter expression.
             $funnelSteps[] = [
                 'name' => $step['name'],
                 'filterExpression' => [
-                    'orGroup' => [
+                    $expressionType => [
                         'expressions' => $funnelFilterExpressionList
                     ]
                 ]

--- a/app/Domain/Funnels/Actions/GenerateFunnelStepsAction.php
+++ b/app/Domain/Funnels/Actions/GenerateFunnelStepsAction.php
@@ -5,6 +5,7 @@ namespace DDD\Domain\Funnels\Actions;
 use Lorisleiva\Actions\Concerns\AsAction;
 use DDD\Domain\Funnels\Funnel;
 use DDD\App\Facades\GoogleAnalytics\GoogleAnalyticsData;
+use DDD\Domain\Funnels\Enums\MetricsExpression;
 
 class GenerateFunnelStepsAction
 {
@@ -29,7 +30,8 @@ class GenerateFunnelStepsAction
                         'metric' => 'pageUsers',
                         'pagePath' => $pagePath,
                     ]
-                ]
+                ],
+                'metrics_expression' => MetricsExpression::default()
             ]);
 
             array_push($steps, $step);

--- a/app/Domain/Funnels/Enums/MetricsExpression.php
+++ b/app/Domain/Funnels/Enums/MetricsExpression.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace DDD\Domain\Funnels\Enums;
+
+class MetricsExpression
+{
+    public const OR_GROUP = 'orGroup';
+    public const AND_GROUP = 'andGroup';
+
+    public static function all(): array
+    {
+        return [
+            self::OR_GROUP,
+            self::AND_GROUP,
+        ];
+    }
+
+    public static function default(): string
+    {
+        return self::OR_GROUP;
+    }
+}

--- a/app/Domain/Funnels/FunnelStep.php
+++ b/app/Domain/Funnels/FunnelStep.php
@@ -41,7 +41,7 @@ class FunnelStep extends Model
     {
         static::updated(function ($funnelStep) {
             // Define the fields that should trigger the job when changed
-            $watchedFields = ['order', 'metrics'];
+            $watchedFields = ['order', 'metrics', 'metrics_expression'];
             $changes = $funnelStep->getChanges();
             $significantChanges = array_intersect_key($changes, array_flip($watchedFields));
             

--- a/app/Domain/Funnels/Requests/StepCreateRequest.php
+++ b/app/Domain/Funnels/Requests/StepCreateRequest.php
@@ -6,6 +6,7 @@ use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Contracts\Validation\Validator;
 use Illuminate\Http\Exceptions\HttpResponseException;
 use DDD\Domain\Funnels\Enums\MatchType;
+use DDD\Domain\Funnels\Enums\MetricsExpression;
 
 class StepCreateRequest extends FormRequest
 {
@@ -27,6 +28,7 @@ class StepCreateRequest extends FormRequest
     public function rules()
     {
         $allowedMatchTypes = implode(',', MatchType::common());
+        $allowedMetricsExpressions = implode(',', MetricsExpression::all());
 
         return [
             'order' => 'nullable|numeric',
@@ -45,6 +47,7 @@ class StepCreateRequest extends FormRequest
             'metrics.*.formLength' => 'nullable|string',
             'metrics.*.formSubmitText' => 'nullable|string',
             'metrics.*.hostname' => 'nullable|string',
+            'metrics_expression' => "nullable|string|in:{$allowedMetricsExpressions}",
         ];
     }
 

--- a/app/Domain/Funnels/Requests/StepUpdateRequest.php
+++ b/app/Domain/Funnels/Requests/StepUpdateRequest.php
@@ -6,6 +6,7 @@ use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Contracts\Validation\Validator;
 use Illuminate\Http\Exceptions\HttpResponseException;
 use DDD\Domain\Funnels\Enums\MatchType;
+use DDD\Domain\Funnels\Enums\MetricsExpression;
 
 class StepUpdateRequest extends FormRequest
 {
@@ -27,6 +28,7 @@ class StepUpdateRequest extends FormRequest
     public function rules()
     {
         $allowedMatchTypes = implode(',', MatchType::common());
+        $allowedMetricsExpressions = implode(',', MetricsExpression::all());
 
         return [
             'order' => 'nullable|numeric',
@@ -45,6 +47,7 @@ class StepUpdateRequest extends FormRequest
             'metrics.*.formLength' => 'nullable|string',
             'metrics.*.formSubmitText' => 'nullable|string',
             'metrics.*.hostname' => 'nullable|string',
+            'metrics_expression' => "nullable|string|in:{$allowedMetricsExpressions}",
         ];
     }
 

--- a/app/Domain/Funnels/Resources/FunnelStepResource.php
+++ b/app/Domain/Funnels/Resources/FunnelStepResource.php
@@ -3,6 +3,7 @@
 namespace DDD\Domain\Funnels\Resources;
 
 use Illuminate\Http\Resources\Json\JsonResource;
+use DDD\Domain\Funnels\Enums\MetricsExpression;
 
 class FunnelStepResource extends JsonResource
 {
@@ -20,6 +21,7 @@ class FunnelStepResource extends JsonResource
             'order' => $this->order,
             'name' => $this->name,
             'metrics' => $this->metrics,
+            'metrics_expression' => $this->metrics_expression ?? MetricsExpression::default(),
             'users' => '0',
             'conversionRate' => '0.00'
         ];

--- a/database/migrations/2025_04_18_000000_add_metrics_expression_to_funnel_steps_table.php
+++ b/database/migrations/2025_04_18_000000_add_metrics_expression_to_funnel_steps_table.php
@@ -1,0 +1,25 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('funnel_steps', function (Blueprint $table) {
+            $table->string('metrics_expression')
+                  ->after('metrics')
+                  ->default('orGroup')
+                  ->nullable();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('funnel_steps', function (Blueprint $table) {
+            $table->dropColumn('metrics_expression');
+        });
+    }
+};


### PR DESCRIPTION
## Summary
- allow funnel steps to specify `metrics_expression` controlling OR/AND logic
- expose metrics_expression through API resources and requests
- add migration and enum for metrics expression values

## Testing
- `./vendor/bin/pest` *(fails: No such file or directory)*
- `composer install --ignore-platform-reqs` *(fails: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_b_68ace0dffe6c83239dd3f82f01982d7c